### PR TITLE
Resolved firebase auth error: auth/account-exists-with-different-credential

### DIFF
--- a/components/common/Login.tsx
+++ b/components/common/Login.tsx
@@ -1,5 +1,6 @@
 // firebase related
 import {
+  linkWithPopup,
   GithubAuthProvider,
   GoogleAuthProvider,
   signInWithPopup
@@ -37,20 +38,21 @@ const Login = () => {
         // The signed-in user info.
         const user = result.user;
         console.log('user is: ', user);
-        window.location.reload();
+        // window.location.reload();
       })
       .catch((error) => {
-        // Handle Errors here.
         const errorCode = error.code;
-        console.log('errorCode is: ', errorCode);
-        const errorMessage = error.message;
-        console.log('errorMessage is: ', errorMessage);
-        // The email of the user's account used.
-        const email = error.email;
-        console.log('email is: ', email);
-        // The AuthCredential type that was used.
-        const credential = GoogleAuthProvider.credentialFromError(error);
-        console.log('credential is: ', credential);
+        if (errorCode === 'auth/account-exists-with-different-credential') {
+          // OAuth providers are only available for Google and GitHub, so if this error occurs at Google, sign in at GitHub.
+          signInWithPopup(auth, githubProvider).then(() => {
+            if (auth.currentUser) {
+              // Link a Google account to a GitHub account
+              linkWithPopup(auth.currentUser, googleProvider);
+            }
+          });
+        } else {
+          window.location.reload();
+        }
       });
   };
 
@@ -65,20 +67,21 @@ const Login = () => {
         console.log('token is: ', token);
         const user = result.user;
         console.log('user is: ', user);
-        window.location.reload();
+        // window.location.reload();
       })
       .catch((error) => {
-        // Handle Errors here.
         const errorCode = error.code;
-        console.log('errorCode is: ', errorCode);
-        const errorMessage = error.message;
-        console.log('errorMessage is: ', errorMessage);
-        // The email of the user's account used.
-        const email = error.email;
-        console.log('email is: ', email);
-        // The AuthCredential type that was used.
-        const credential = GoogleAuthProvider.credentialFromError(error);
-        console.log('credential is: ', credential);
+        if (errorCode === 'auth/account-exists-with-different-credential') {
+          // OAuth providers are only available for Google and GitHub, so if this error occurs at GitHub, sign in at Google.
+          signInWithPopup(auth, googleProvider).then(() => {
+            if (auth.currentUser) {
+              // Link a Github account to a Google account
+              linkWithPopup(auth.currentUser, githubProvider);
+            }
+          });
+        } else {
+          window.location.reload();
+        }
       });
   };
 

--- a/components/common/Logout.tsx
+++ b/components/common/Logout.tsx
@@ -6,7 +6,8 @@ const LogOut = () => {
   const handleClick = () => {
     signOut(auth)
       .then(() => {
-        window.location.reload(); // https://developer.mozilla.org/en-US/docs/Web/API/Location/reload
+        console.log('signed out');
+        // window.location.reload(); // https://developer.mozilla.org/en-US/docs/Web/API/Location/reload
       })
       .catch((error) => {
         console.log('error is: ', error);


### PR DESCRIPTION
## About

If a user already signed in this app with google account, then the user would try to sign in with github account, then this error happen and the sign in process would fail.
With this PR, a user can link second OAuth account with first OAuth account, without any errors.

## Evidence:

https://drive.google.com/open?id=1B9ofzSO06aryfPsEmG57L0yOVzlzcGs9&authuser=nishio.hiroshi%40suchica.com&usp=drive_fs

## References:

https://firebase.google.com/docs/auth/web/account-linking
https://firebase.google.com/docs/reference/js/auth.md#linkwithpopup
https://firebase.google.com/docs/auth/web/google-signin#expandable-1 * A little bit outdated I think.

## Others:

And removed unnecessary reload functions.
