### PR TITLE
Resolved firebase error: auth/id-token-expired every 1 hour in getServerSideProps

### DIFF
--- a/auth.tsx
+++ b/auth.tsx
@@ -33,6 +33,16 @@ export const AuthProvider: FC = ({ children }) => {
     });
   }, []);
 
+  // force refresh the token every 10 minutes
+  useEffect(() => {
+    const handle = setInterval(async () => {
+      console.log('refreshing token...');
+      const user = auth.currentUser;
+      if (user) await user.getIdToken(true); // true to force refresh
+    }, 10 * 60 * 1000);
+    return () => clearInterval(handle);
+  }, []);
+
   if (loading) {
     return <Loading type='spinningBubbles' color='yellowgreen' />;
   }

--- a/components/common/Login.tsx
+++ b/components/common/Login.tsx
@@ -38,7 +38,7 @@ const Login = () => {
         // The signed-in user info.
         const user = result.user;
         console.log('user is: ', user);
-        // window.location.reload();
+        window.location.reload();
       })
       .catch((error) => {
         const errorCode = error.code;
@@ -67,7 +67,7 @@ const Login = () => {
         console.log('token is: ', token);
         const user = result.user;
         console.log('user is: ', user);
-        // window.location.reload();
+        window.location.reload();
       })
       .catch((error) => {
         const errorCode = error.code;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -115,7 +115,9 @@ export default function Home({
 export const getServerSideProps: GetServerSideProps = async (
   ctx: GetServerSidePropsContext
 ) => {
+  // console.log('ctx is: ', ctx);
   const cookies = nookies.get(ctx);
+  // console.log('cookies is: ', cookies);
 
   if (cookies.token) {
     const token = await verifyIdToken(cookies.token);


### PR DESCRIPTION
## 1. About:

Normally firebase automatically updates its token, but with getServerSideProps, it runs before client side rendering, so it might use expired token because automatic updates by getIdToken() can only run in client side.
This continuously occur every 1 hour, so it needs to be fixed asap.

## 2. Evidences:

### 9:29 May 3, 2022 was here.

![image](https://user-images.githubusercontent.com/4620828/166347884-f04ae151-0fa1-4776-bd4d-e630a85a6c1b.png)

### 10:38 May 3, 2022 was here. No error happened !!

![image](https://user-images.githubusercontent.com/4620828/166393002-5ed0add2-db38-421e-a8ec-b79a913ed15a.png)

### Others

1. User settings page worked
2. logout button worked
3. login button worked

## 3. Caveats

One point, an error now occurs when the network is disconnected. This will be addressed as a separate issue.

![image](https://user-images.githubusercontent.com/4620828/166483278-49d749e3-3626-4c92-bddb-7098bc08e2d6.png)

## 4. References:

https://colinhacks.com/essays/nextjs-firebase-authentication
https://stackoverflow.com/questions/65261134/firebase-authentication-token-expiration-with-next-js-ssr